### PR TITLE
RBAC: Webhook checks for placeholders in secrets and configmaps

### DIFF
--- a/templates/vault-secrets-webhook/rbac-for-us.yaml
+++ b/templates/vault-secrets-webhook/rbac-for-us.yaml
@@ -14,6 +14,13 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - secrets
+  - configmaps
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
   - serviceaccounts/token
   verbs:
   - create


### PR DESCRIPTION
## Description
RBAC to access to CM and Secrets

## Why do we need it, and what problem does it solve?
Placeholders can be in CM or in secret, this needs to be checked to decide whether it is necessary to mutate pod

## What is the expected result?
    envFrom:
    - configMapRef:
should work

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
