### PR TITLE
Ability to extract command from images in private registries

### DIFF
--- a/templates/vault-secrets-webhook/rbac-for-us.yaml
+++ b/templates/vault-secrets-webhook/rbac-for-us.yaml
@@ -24,6 +24,12 @@ rules:
   - serviceaccounts/token
   verbs:
   - create
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
## Description
Ability to extract command from images in private registries

## Why do we need it, and what problem does it solve?
A pod manifest can be used without the "command" field, so we need to extract the original command from the image manifest

## What is the expected result?
```yaml
spec:
  serviceAccountName: nginx
  imagePullSecrets:
    - name: regsecret
  containers:
  - image: my.privateregistry.com/repo/nginx:latest
    name: nginx
```
must mutate to
```yaml
spec:
  serviceAccountName: nginx
  imagePullSecrets:
    - name: regsecret
  containers:
  - image: my.privateregistry.com/repo/nginx:latest
    name: nginx
    command:
    - /vault/env-injector
    args:
    - /docker-entrypoint.sh
    - nginx
    - -g
    - daemon off;
```


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
