### PR TITLE
[webhook] set mutate policy to Fail

### DIFF
--- a/templates/vault-secrets-webhook/mutatingwebhookconfiguration.yaml
+++ b/templates/vault-secrets-webhook/mutatingwebhookconfiguration.yaml
@@ -22,7 +22,7 @@ webhooks:
     - "*"
     resources:
     - pods
-  failurePolicy: Ignore
+  failurePolicy: Fail
   namespaceSelector:
     matchExpressions:
     - key: kubernetes.io/metadata.name


### PR DESCRIPTION
## Description
Do not create pods if mutation fails

## Why do we need it, and what problem does it solve?
If the webhook fails, pods may be created without environment variables.
The best solution is to not create these pods until the webhook starts working again.

## What is the expected result?
If the webhook service is not running, pods should not be created.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.