### PR TITLE
Ability to skip container mutation (for example for istio)

### DIFF
--- a/docs/USAGE_RU.md
+++ b/docs/USAGE_RU.md
@@ -114,7 +114,7 @@ export VAULT_ADDR=https://secretstoreexample.com
 
   ```bash
   stronghold kv get demo-kv/myapp-secret
-  ```  
+  ```
 
   Команда с использованием curl:
   ```bash
@@ -174,8 +174,8 @@ export VAULT_ADDR=https://secretstoreexample.com
 * Создаём роль, состоящую из названия пространства имён и политики. Связываем её с ServiceAccount `myapp-sa` из пространства имён `myapp-namespace` и политикой `myapp-ro-policy`:
 
   {{< alert level="danger">}}
-  **Важно!**  
-  Помимо настроек со стороны Stronghold, вы должны настроить разрешения авторизации используемых `serviceAccount` в кластере kubernetes.  
+  **Важно!**
+  Помимо настроек со стороны Stronghold, вы должны настроить разрешения авторизации используемых `serviceAccount` в кластере kubernetes.
   Подробности в пункте [ниже](#как-разрешить-serviceaccount-авторизоваться-в-stronghold)
   {{< /alert >}}
 
@@ -216,7 +216,7 @@ export VAULT_ADDR=https://secretstoreexample.com
 
 
 {{< alert level="info">}}
-**Важно!**  
+**Важно!**
 Рекомендованное значение TTL для токена Kubernetes составляет 10m.
 {{< /alert >}}
 
@@ -255,6 +255,7 @@ Stronghold может использовать различные авториз
 |secrets-store.deckhouse.io/mutate-probes          | false     | Инжектирует переменные окружения в пробы |
 |secrets-store.deckhouse.io/log-level              | info      | Уровень логирования |
 |secrets-store.deckhouse.io/enable-json-log        | false     | Формат логов, строка или json |
+|secrets-store.deckhouse.io/skip-mutate-containers |           | Список имен контейнеров через пробел, к которым не будет применятся инжектирование |
 
 Используя инжектор вы сможете задавать в манифестах пода вместо значений env-шаблоны, которые будут заменяться на этапе запуска контейнера на значения из хранилища.
 

--- a/images/env-injector/go.mod
+++ b/images/env-injector/go.mod
@@ -62,7 +62,7 @@ require (
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/crypto v0.31.0 // indirect
 	golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1 // indirect
-	golang.org/x/net v0.26.0 // indirect
+	golang.org/x/net v0.33.0 // indirect
 	golang.org/x/oauth2 v0.20.0 // indirect
 	golang.org/x/sync v0.10.0 // indirect
 	golang.org/x/sys v0.28.0 // indirect

--- a/images/env-injector/go.sum
+++ b/images/env-injector/go.sum
@@ -203,8 +203,8 @@ golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20200202094626-16171245cfb2/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
-golang.org/x/net v0.26.0 h1:soB7SVo0PWrY4vPW/+ay0jKDNScG2X9wFeYlXIvJsOQ=
-golang.org/x/net v0.26.0/go.mod h1:5YKkiSynbBIh3p6iOc/vibscux0x38BZDkn8sCUPxHE=
+golang.org/x/net v0.33.0 h1:74SYHlV8BIgHIFC/LrYkOGIwL19eTYXQ5wc6TBuO36I=
+golang.org/x/net v0.33.0/go.mod h1:HXLR5J+9DxmrqMwG9qjGCxZ+zKXxBru04zlTvWlWuN4=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.20.0 h1:4mQdhULixXKP1rwYBW0vAijoXnkTG0BLCDRzfe1idMo=
 golang.org/x/oauth2 v0.20.0/go.mod h1:XYTD2NtWslqkgxebSiOHnXEap4TF09sJSc7H1sXbhtI=

--- a/images/vault-secrets-webhook/go.mod
+++ b/images/vault-secrets-webhook/go.mod
@@ -142,7 +142,7 @@ require (
 	go.uber.org/zap v1.27.0 // indirect
 	golang.org/x/crypto v0.31.0 // indirect
 	golang.org/x/exp v0.0.0-20230905200255-921286631fa9 // indirect
-	golang.org/x/net v0.30.0 // indirect
+	golang.org/x/net v0.33.0 // indirect
 	golang.org/x/oauth2 v0.22.0 // indirect
 	golang.org/x/sync v0.10.0 // indirect
 	golang.org/x/sys v0.28.0 // indirect

--- a/images/vault-secrets-webhook/go.sum
+++ b/images/vault-secrets-webhook/go.sum
@@ -424,8 +424,8 @@ golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
 golang.org/x/net v0.6.0/go.mod h1:2Tu9+aMcznHK/AK1HMvgo6xiTLG5rD5rZLDS+rp2Bjs=
-golang.org/x/net v0.30.0 h1:AcW1SDZMkb8IpzCdQUaIq2sP4sZ4zw+55h6ynffypl4=
-golang.org/x/net v0.30.0/go.mod h1:2wGyMJ5iFasEhkwi13ChkO/t1ECNC4X4eBKkVFyYFlU=
+golang.org/x/net v0.33.0 h1:74SYHlV8BIgHIFC/LrYkOGIwL19eTYXQ5wc6TBuO36I=
+golang.org/x/net v0.33.0/go.mod h1:HXLR5J+9DxmrqMwG9qjGCxZ+zKXxBru04zlTvWlWuN4=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.22.0 h1:BzDx2FehcG7jJwgWLELCdmLuxk2i+x9UDpSiss2u0ZA=
 golang.org/x/oauth2 v0.22.0/go.mod h1:XYTD2NtWslqkgxebSiOHnXEap4TF09sJSc7H1sXbhtI=

--- a/images/vault-secrets-webhook/pkg/common/common.go
+++ b/images/vault-secrets-webhook/pkg/common/common.go
@@ -37,8 +37,8 @@ const (
 	VaultNamespaceAnnotation                = "secrets-store.deckhouse.io/namespace"
 	ServiceAccountTokenVolumeNameAnnotation = "secrets-store.deckhouse.io/service-account-token-volume-name"
 	LogLevelAnnotation                      = "secrets-store.deckhouse.io/log-level"
-	VaultEnvFromPathAnnotation = "secrets-store.deckhouse.io/env-from-path"
-
+	VaultEnvFromPathAnnotation              = "secrets-store.deckhouse.io/env-from-path"
+	SkipMutateContainersAnnotation          = "secrets-store.deckhouse.io/skip-mutate-containers"
 )
 
 func HasVaultPrefix(value string) bool {

--- a/images/vault-secrets-webhook/pkg/webhook/config.go
+++ b/images/vault-secrets-webhook/pkg/webhook/config.go
@@ -18,6 +18,7 @@ package webhook
 
 import (
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/slok/kubewebhook/v2/pkg/model"
@@ -66,6 +67,7 @@ type VaultConfig struct {
 	ObjectNamespace               string
 	MutateProbes                  bool
 	Token                         string
+	SkipMutateContainers          []string
 }
 
 func parseVaultConfig(obj metav1.Object, ar *model.AdmissionReview) VaultConfig {
@@ -142,6 +144,12 @@ func parseVaultConfig(obj metav1.Object, ar *model.AdmissionReview) VaultConfig 
 
 	vaultConfig.EnvLogServer = viper.GetString("VAULT_ENV_LOG_SERVER")
 
+	if val, ok := annotations[common.SkipMutateContainersAnnotation]; ok {
+		vaultConfig.SkipMutateContainers = strings.Fields(val)
+	} else {
+		vaultConfig.SkipMutateContainers = viper.GetStringSlice("skip_mutate_containers")
+	}
+
 	if val, ok := annotations[common.VaultNamespaceAnnotation]; ok {
 		vaultConfig.VaultNamespace = val
 	} else {
@@ -180,6 +188,7 @@ func SetConfigDefaults() {
 	viper.SetDefault("env_injector_pull_policy", string(corev1.PullIfNotPresent))
 	viper.SetDefault("addr", "https://stronghold.d8-stronghold:8200")
 	viper.SetDefault("tls_skip_verify", "false")
+	viper.SetDefault("skip_mutate_containers", "")
 	viper.SetDefault("auth_path", "kubernetes_local")
 	viper.SetDefault("auth_method", "jwt")
 	viper.SetDefault("role", "")

--- a/images/vault-secrets-webhook/pkg/webhook/pod.go
+++ b/images/vault-secrets-webhook/pkg/webhook/pod.go
@@ -156,6 +156,17 @@ func (mw *MutatingWebhook) mutateContainers(ctx context.Context, containers []co
 			continue
 		}
 
+		if func() bool {
+			for _, skipContainerName := range vaultConfig.SkipMutateContainers {
+				if container.Name == skipContainerName {
+					return true
+				}
+			}
+			return false
+		}() {
+			continue
+		}
+
 		mutated = true
 
 		args := container.Command

--- a/lib/python/requirements.txt
+++ b/lib/python/requirements.txt
@@ -1,4 +1,4 @@
 deckhouse==0.4.9
 dotmap==1.3.30
 PyYAML==6.0.1
-cryptography==43.0.1
+cryptography==44.0.1

--- a/templates/registry-secret.yaml
+++ b/templates/registry-secret.yaml
@@ -12,6 +12,8 @@ data:
   .dockerconfigjson: {{ . }}
 {{- end }}
 {{- else }}
+{{- if .Values.global.registry }}
+{{- with .Values.global.registry.dockercfg }}
 ---
 apiVersion: v1
 kind: Secret
@@ -21,5 +23,7 @@ metadata:
   {{- include "helm_lib_module_labels" (list $ (dict "app" $.Chart.Name )) | nindent 2 }}
 type: kubernetes.io/dockerconfigjson
 data:
-  .dockerconfigjson: {{ .Values.global.registry.dockercfg }}
+  .dockerconfigjson: {{ . }}
+{{- end }}
+{{- end }}
 {{- end }}

--- a/templates/vault-secrets-webhook/deployment.yaml
+++ b/templates/vault-secrets-webhook/deployment.yaml
@@ -69,6 +69,8 @@ spec:
           value: "true"
         - name: TELEMETRY_LISTEN_ADDRESS
           value: "127.0.0.1:8000"
+        - name: SKIP_MUTATE_CONTAINERS
+          value: "check-linux-kernel istio-validation istio-proxy istio-init"
         {{- if eq .Values.secretsStoreIntegration.connectionConfiguration "Manual" }}
         - name: ADDR
           value: {{ .Values.secretsStoreIntegration.connection.url }}


### PR DESCRIPTION
## Description
- Ability to skip the mutation of certain containers via the `secrets-store.deckhouse.io/skip-mutate-containers` pod annotation or the `skip_mutate_containers` webhook environment variable.
- CVE updates

## Why do we need it, and what problem does it solve?
Istio initContainers do not have access to Vault when using the `secrets-store.deckhouse.io/env-from-path` annotation, so we want to skip such containers.

## What is the expected result?
Pods with the `secrets-store.deckhouse.io/env-from-path` annotation and the `sidecar.istio.io/inject: "true"` label can start successfully.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.