### PR TITLE
Added annotations to configure vault addr and auth path

### DIFF
--- a/images/vault-secrets-webhook/pkg/webhook/config.go
+++ b/images/vault-secrets-webhook/pkg/webhook/config.go
@@ -84,9 +84,19 @@ func parseVaultConfig(obj metav1.Object, ar *model.AdmissionReview) VaultConfig 
 		return vaultConfig
 	}
 
-	vaultConfig.Addr = viper.GetString("addr")
+	if val, ok := annotations[common.VaultAddrAnnotation]; ok {
+		vaultConfig.Addr = val
+	} else {
+		vaultConfig.Addr = viper.GetString("addr")
+	}
+
 	vaultConfig.AuthMethod = "jwt"
-	vaultConfig.Path = viper.GetString("auth_path")
+
+	if val, ok := annotations[common.VaultPathAnnotation]; ok {
+		vaultConfig.Path = val
+	} else {
+		vaultConfig.Path = viper.GetString("auth_path")
+	}
 
 	if val, ok := annotations[common.VaultSkipVerifyAnnotation]; ok {
 		vaultConfig.SkipVerify, _ = strconv.ParseBool(val)


### PR DESCRIPTION
## Description
Added annotations to configure vault addr and auth path

## Why do we need it, and what problem does it solve?
When you need to use different Vault server, not form module config

## What is the expected result?
Vault address can be configurable via annotation

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
