### PR TITLE
Namespaces support

### DIFF
--- a/crds/doc-ru-secrets-store-import.yaml
+++ b/crds/doc-ru-secrets-store-import.yaml
@@ -11,7 +11,17 @@ spec:
               type:
                 description: В данный момент поддерживается только тип CSI
               role:
-                description: Роль в vault-совместимом хранилище
+                description: Роль в Vault-совместимом хранилище
+              namespace:
+                description: Пространство имен секрета. Если не указано, используется значение из ModuleConfig
+              address:
+                description: Адрес Vault-совместимого хранилища секретов. Если не указано, используется значение из ModuleConfig
+              caCert:
+                description: CA сертификат Stronghold или Vault в формате PEM. Если не указано, используется значение из ModuleConfig
+              audience:
+                description: Получателя токена JWT, или аудитория
+              skipTLSVerify:
+                description: Не проверять сертификат TLS
               files:
                 items:
                   properties:
@@ -23,3 +33,4 @@ spec:
                           description: Путь в Vault-совместимом kv хранилище
                         key:
                           description: Ключ в Vault-совместимом kv хранилище
+

--- a/crds/secrets-store-import.yaml
+++ b/crds/secrets-store-import.yaml
@@ -43,15 +43,21 @@ spec:
                 description: Role in vault-compatible storage
               authPath:
                 type: string
-                pattern: ^[-_\.a-zA-Z0-9]+$
+                pattern: ^[-_.a-zA-Z0-9]+$
                 description: Auth path in vault-compatible storage
               namespace:
                 type: string
-                pattern: ^[-_\.\/a-zA-Z0-9]+$
+                pattern: ^[-_./a-zA-Z0-9]+$
                 description: Namespace where secret is stored
               address:
                 type: string
+                pattern: ^https?://[.:0-9a-zA-Z-]+$
                 description: Address of vault-compatible storage
+              caCert:
+                type: string
+                pattern: "^-----BEGIN CERTIFICATE-----\n(.+\n){5}"
+                description: |
+                  Stronghold or vault CA in PEM format
               audience:
                 type: string
                 description: JWT audience

--- a/crds/secrets-store-import.yaml
+++ b/crds/secrets-store-import.yaml
@@ -41,6 +41,14 @@ spec:
                 type: string
                 pattern: ^[-_\.a-zA-Z0-9]+$
                 description: Role in vault-compatible storage
+              authPath:
+                type: string
+                pattern: ^[-_\.a-zA-Z0-9]+$
+                description: Auth path in vault-compatible storage
+              namespace:
+                type: string
+                pattern: ^[-a-zA-Z0-9]+$
+                description: Namespace where secret is stored
               files:
                 type: array
                 items:

--- a/crds/secrets-store-import.yaml
+++ b/crds/secrets-store-import.yaml
@@ -47,8 +47,17 @@ spec:
                 description: Auth path in vault-compatible storage
               namespace:
                 type: string
-                pattern: ^[-a-zA-Z0-9]+$
+                pattern: ^[-_\.\/a-zA-Z0-9]+$
                 description: Namespace where secret is stored
+              address:
+                type: string
+                description: Address of vault-compatible storage
+              audience:
+                type: string
+                description: JWT audience
+              skipTLSVerify:
+                type: boolean
+                description: Skip TLS verification
               files:
                 type: array
                 items:

--- a/crds/secrets-store-import.yaml
+++ b/crds/secrets-store-import.yaml
@@ -40,24 +40,24 @@ spec:
               role:
                 type: string
                 pattern: ^[-_\.a-zA-Z0-9]+$
-                description: Role in vault-compatible storage
+                description: Role in Vault-compatible storage
               authPath:
                 type: string
                 pattern: ^[-_.a-zA-Z0-9]+$
-                description: Auth path in vault-compatible storage
+                description: Auth path in Vault-compatible storage
               namespace:
                 type: string
                 pattern: ^[-_./a-zA-Z0-9]+$
-                description: Namespace where secret is stored
+                description: Namespace where secret is stored. If omitted value from ModuleConfig will be used.
               address:
                 type: string
                 pattern: ^https?://[.:0-9a-zA-Z-]+$
-                description: Address of vault-compatible storage
+                description: Address of Vault-compatible storage. If omitted value from ModuleConfig will be used.
               caCert:
                 type: string
                 pattern: "^-----BEGIN CERTIFICATE-----\n(.+\n){5}"
                 description: |
-                  Stronghold or vault CA in PEM format
+                  Stronghold or Vault CA in PEM format. If omitted value from ModuleConfig will be used.
               audience:
                 type: string
                 description: JWT audience

--- a/hooks/hook.py
+++ b/hooks/hook.py
@@ -63,8 +63,10 @@ def main(ctx: hook.Context):
             sps['spec']['parameters']['vaultAuthMountPath'] = ssi['filterResult']['spec'].get('authPath')
             sps['spec']['parameters']['vaultNamespace'] = ssi['filterResult']['spec'].get('namespace')
             sps['spec']['parameters']['vaultAddress'] = ssi['filterResult']['spec'].get('address')
+            sps['spec']['parameters']['vaultCACert'] = ssi['filterResult']['spec'].get('caCert')
             sps['spec']['parameters']['audience'] = ssi['filterResult']['spec'].get('audience')
-            sps['spec']['parameters']['vaultSkipTLSVerify'] = ssi['filterResult']['spec'].get('skipTLSVerify')
+            if (skip_tls:=ssi['filterResult']['spec'].get('skipTLSVerify')):
+                sps['spec']['parameters']['vaultSkipTLSVerify'] = str(skip_tls).lower()
             sps['spec']['secretObjects'][0]['secretName'] = name
             for obj in ssi['filterResult']['spec']['files']:
                 sps['spec']['parameters']['objects'] += '- objectName: ' + \
@@ -90,8 +92,10 @@ def main(ctx: hook.Context):
             sps['spec']['parameters']['vaultAuthMountPath'] = ctx.binding_context['filterResult']['spec'].get('authPath')
             sps['spec']['parameters']['vaultNamespace'] = ctx.binding_context['filterResult']['spec'].get('namespace')
             sps['spec']['parameters']['vaultAddress'] = ctx.binding_context['filterResult']['spec'].get('address')
+            sps['spec']['parameters']['vaultCACert'] = ctx.binding_context['filterResult']['spec'].get('caCert')
             sps['spec']['parameters']['audience'] = ctx.binding_context['filterResult']['spec'].get('audience')
-            sps['spec']['parameters']['vaultSkipTLSVerify'] = ctx.binding_context['filterResult']['spec'].get('skipTLSVerify')
+            if (skip_tls:=ctx.binding_context['filterResult']['spec'].get('skipTLSVerify')):
+                sps['spec']['parameters']['vaultSkipTLSVerify'] = str(skip_tls).lower()
             sps['spec']['secretObjects'][0]['secretName'] = name
             for obj in ctx.binding_context['filterResult']['spec']['files']:
                 sps['spec']['parameters']['objects'] += '- objectName: ' + \

--- a/hooks/hook.py
+++ b/hooks/hook.py
@@ -60,6 +60,11 @@ def main(ctx: hook.Context):
             sps['metadata']['name'] = name
             sps['metadata']['namespace'] = namespace
             sps['spec']['parameters']['roleName'] = ssi['filterResult']['spec']['role']
+            sps['spec']['parameters']['vaultAuthMountPath'] = ssi['filterResult']['spec'].get('authPath')
+            sps['spec']['parameters']['vaultNamespace'] = ssi['filterResult']['spec'].get('namespace')
+            sps['spec']['parameters']['vaultAddress'] = ssi['filterResult']['spec'].get('address')
+            sps['spec']['parameters']['audience'] = ssi['filterResult']['spec'].get('audience')
+            sps['spec']['parameters']['vaultSkipTLSVerify'] = ssi['filterResult']['spec'].get('skipTLSVerify')
             sps['spec']['secretObjects'][0]['secretName'] = name
             for obj in ssi['filterResult']['spec']['files']:
                 sps['spec']['parameters']['objects'] += '- objectName: ' + \
@@ -82,6 +87,11 @@ def main(ctx: hook.Context):
             sps['metadata']['name'] = name
             sps['metadata']['namespace'] = namespace
             sps['spec']['parameters']['roleName'] = ctx.binding_context['filterResult']['spec']['role']
+            sps['spec']['parameters']['vaultAuthMountPath'] = ctx.binding_context['filterResult']['spec'].get('authPath')
+            sps['spec']['parameters']['vaultNamespace'] = ctx.binding_context['filterResult']['spec'].get('namespace')
+            sps['spec']['parameters']['vaultAddress'] = ctx.binding_context['filterResult']['spec'].get('address')
+            sps['spec']['parameters']['audience'] = ctx.binding_context['filterResult']['spec'].get('audience')
+            sps['spec']['parameters']['vaultSkipTLSVerify'] = ctx.binding_context['filterResult']['spec'].get('skipTLSVerify')
             sps['spec']['secretObjects'][0]['secretName'] = name
             for obj in ctx.binding_context['filterResult']['spec']['files']:
                 sps['spec']['parameters']['objects'] += '- objectName: ' + \

--- a/images/vault-csi-provider/patches/002-cert-bytes.patch
+++ b/images/vault-csi-provider/patches/002-cert-bytes.patch
@@ -1,0 +1,14 @@
+diff --git a/internal/config/config.go b/internal/config/config.go
+index fb4af20..7a44bd5 100644
+--- a/internal/config/config.go
++++ b/internal/config/config.go
+@@ -132,6 +132,9 @@ func parseParameters(parametersStr string) (Parameters, error) {
+ 	parameters.VaultRoleName = params["roleName"]
+ 	parameters.VaultAddress = params["vaultAddress"]
+ 	parameters.VaultNamespace = params["vaultNamespace"]
++	if cert, ok := params["vaultCACert"]; ok {
++		parameters.VaultTLSConfig.CACertBytes = []byte(cert)
++	}
+ 	parameters.VaultTLSConfig.CACert = params["vaultCACertPath"]
+ 	parameters.VaultTLSConfig.CAPath = params["vaultCADirectory"]
+ 	parameters.VaultTLSConfig.TLSServerName = params["vaultTLSServerName"]

--- a/images/vault-csi-provider/patches/README.md
+++ b/images/vault-csi-provider/patches/README.md
@@ -3,3 +3,7 @@
 ### 001-gomod.patch
 
 CVE fixes
+
+### 002-cert-bytes.patch
+
+Added field for providing CA certificate with string value

--- a/openapi/config-values.yaml
+++ b/openapi/config-values.yaml
@@ -5,14 +5,17 @@ oneOf:
     connectionConfiguration:
       type: string
       enum: ["DiscoverLocalStronghold"]
-  not:
-    required:
-    - connection
+    connection:
+      not:
+        required:
+          - url
 - properties:
     connectionConfiguration:
       type: string
       enum: ["Manual"]
-    connection: {}
+    connection:
+      required:
+        - url
   required:
   - connection
 properties:
@@ -25,8 +28,6 @@ properties:
     default: "DiscoverLocalStronghold"
   connection:
     type: object
-    required:
-      - url
     properties:
       url:
         type: string

--- a/openapi/config-values.yaml
+++ b/openapi/config-values.yaml
@@ -32,13 +32,13 @@ properties:
         type: string
         pattern: ^https://[\.:0-9a-zA-Z-]+$
         description: |
-          Stronghold or vault address
+          Stronghold or Vault address
         x-examples: [ "https://vault.mycompany.com:8200" ]
       caCert:
         type: string
         pattern: "^-----BEGIN CERTIFICATE-----\n(.+\n){5}"
         description: |
-          Stronghold or vault CA in PEM format
+          Stronghold or Vault CA in PEM format
       authPath:
         type: string
         pattern: ^[A-Za-z0-9-_]+$
@@ -46,3 +46,9 @@ properties:
         description: |
           Kubernetes Mount Path
         x-examples: [ "kubernetes", "kube-dev" ]
+      namespace:
+        type: string
+        pattern: ^[A-Za-z0-9-_\/]+$
+        description: |
+          Namespace in Vault-compatible store
+        x-examples: [ "ns1", "ns1/sub-ns2" ]

--- a/openapi/doc-ru-config-values.yaml
+++ b/openapi/doc-ru-config-values.yaml
@@ -21,3 +21,6 @@ properties:
         type: string
         description: |
           Путь в Stronghold/Vault для подключения авторизации kubernetes
+      namespace:
+        description: |
+          Пространство имен в Vault-совместимом хранилище

--- a/templates/vault-csi-provider/daemonset.yaml
+++ b/templates/vault-csi-provider/daemonset.yaml
@@ -87,9 +87,12 @@ spec:
           args:
             {{- if eq .Values.secretsStoreIntegration.connectionConfiguration "Manual" }}
             - -vault-addr={{ .Values.secretsStoreIntegration.connection.url }}
-            - -vault-mount={{ .Values.secretsStoreIntegration.connection.authPath }}
             {{- else }}
             - -vault-addr=https://stronghold.d8-stronghold.svc:8300
+            {{- end }}
+            {{- if and (.Values.secretsStoreIntegration.connection) (hasKey .Values.secretsStoreIntegration.connection "authPath") (ne .Values.secretsStoreIntegration.connection.authPath "") }}
+            - -vault-mount={{ .Values.secretsStoreIntegration.connection.authPath }}
+            {{- else }}
             - -vault-mount=kubernetes_local
             {{- end }}
             {{- if and (.Values.secretsStoreIntegration.connection) (hasKey .Values.secretsStoreIntegration.connection "namespace") (ne .Values.secretsStoreIntegration.connection.namespace "") }}

--- a/templates/vault-csi-provider/daemonset.yaml
+++ b/templates/vault-csi-provider/daemonset.yaml
@@ -92,6 +92,9 @@ spec:
             - -vault-addr=https://stronghold.d8-stronghold.svc:8300
             - -vault-mount=kubernetes_local
             {{- end }}
+            {{- if and (.Values.secretsStoreIntegration.connection) (hasKey .Values.secretsStoreIntegration.connection "namespace") (ne .Values.secretsStoreIntegration.connection.namespace "") }}
+            - -vault-namespace={{ .Values.secretsStoreIntegration.connection.namespace }}
+            {{- end }}
             - -endpoint=/provider/vault.sock
             - -debug=false
           resources:

--- a/templates/vault-secrets-webhook/deployment.yaml
+++ b/templates/vault-secrets-webhook/deployment.yaml
@@ -79,6 +79,10 @@ spec:
         - name: AUTH_PATH
           value: {{ .Values.secretsStoreIntegration.connection.authPath }}
         {{- end }}
+        {{- if and (.Values.secretsStoreIntegration.connection) (hasKey .Values.secretsStoreIntegration.connection "namespace") (ne .Values.secretsStoreIntegration.connection.namespace "") }}
+        - name: VAULT_NAMESPACE
+          value: {{ .Values.secretsStoreIntegration.connection.namespace }}
+        {{- end }}
         ports:
         - containerPort: 8443
           name: https

--- a/templates/vault-secrets-webhook/deployment.yaml
+++ b/templates/vault-secrets-webhook/deployment.yaml
@@ -76,6 +76,8 @@ spec:
         {{- if eq .Values.secretsStoreIntegration.connectionConfiguration "Manual" }}
         - name: ADDR
           value: {{ .Values.secretsStoreIntegration.connection.url }}
+        {{- end }}
+        {{- if and (.Values.secretsStoreIntegration.connection) (hasKey .Values.secretsStoreIntegration.connection "authPath") (ne .Values.secretsStoreIntegration.connection.authPath "") }}
         - name: AUTH_PATH
           value: {{ .Values.secretsStoreIntegration.connection.authPath }}
         {{- end }}


### PR DESCRIPTION
## Description
Added authPath and namespace parameters to SecretsStoreImport openapi

## Why do we need it, and what problem does it solve?
Introducing Stronghold namespace settings.

## What is the expected result?
Two parameters available for setting in SecretsStoreImport CR

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
