### PR TITLE
Deduplicate secrets by key

### DIFF
--- a/images/env-injector/injector.go
+++ b/images/env-injector/injector.go
@@ -328,6 +328,8 @@ func (i *SecretInjector) InjectSecretsFromVault(references map[string]string, in
 
 func (i *SecretInjector) InjectSecretsFromVaultPath(paths string, inject SecretInjectorFunc) error {
 	vaultPaths := strings.Split(paths, ",")
+	// to remove duplicates when running with syscall.Exec
+	secretKVs := make(map[string]string)
 
 	for _, path := range vaultPaths {
 		split := strings.SplitN(path, "#", 2)
@@ -363,8 +365,12 @@ func (i *SecretInjector) InjectSecretsFromVaultPath(paths string, inject SecretI
 			if err != nil {
 				return errors.Wrap(err, "value can't be cast to a string for key: "+key)
 			}
-			inject(key, value)
+			secretKVs[key] = value
 		}
+	}
+
+	for key, value := range secretKVs {
+		inject(key, value)
 	}
 
 	return nil

--- a/images/vault-secrets-webhook/pkg/webhook/injector.go
+++ b/images/vault-secrets-webhook/pkg/webhook/injector.go
@@ -332,6 +332,8 @@ func (i *SecretInjector) InjectSecretsFromVault(references map[string]string, in
 
 func (i *SecretInjector) InjectSecretsFromVaultPath(paths string, inject SecretInjectorFunc) error {
 	vaultPaths := strings.Split(paths, ",")
+	// to remove duplicates when running with syscall.Exec
+	secretKVs := make(map[string]string)
 
 	for _, path := range vaultPaths {
 		split := strings.SplitN(path, "#", 2)
@@ -369,8 +371,12 @@ func (i *SecretInjector) InjectSecretsFromVaultPath(paths string, inject SecretI
 			if err != nil {
 				return errors.Wrap(err, "value can't be cast to a string for key: "+key)
 			}
-			inject(key, value)
+			secretKVs[key] = value
 		}
+	}
+
+	for key, value := range secretKVs {
+		inject(key, value)
 	}
 
 	return nil


### PR DESCRIPTION
## Description
- remove duplicate keys when fetching secrets from vault path. Last one in.
 
## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
