### PR TITLE
Add new mount-point for read-only file system

### DIFF
--- a/images/secrets-store-csi-driver/mount-points.yaml
+++ b/images/secrets-store-csi-driver/mount-points.yaml
@@ -2,3 +2,4 @@ dirs:
   - /csi
   - /var/lib/kubelet/pods
   - /var/run/secrets-store-csi-providers
+  - /run/secrets-store-csi-providers

--- a/images/secrets-store-csi-driver/mount-points.yaml
+++ b/images/secrets-store-csi-driver/mount-points.yaml
@@ -1,5 +1,4 @@
 dirs:
   - /csi
   - /var/lib/kubelet/pods
-  - /var/run/secrets-store-csi-providers
   - /run/secrets-store-csi-providers


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Add new mount-point for read-only file system
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Resolve
`runc create failed: unable to start container process: error during container init: error mounting "/var/run/secrets-store-csi-providers" to rootfs at "/var/run/secrets-store-csi-providers": create mountpoint for /var/run/secrets-store-csi-providers mount: mkdirat /run/containerd/io.containerd.runtime.v2.task/k8s.io/secrets-store/rootfs/run/secrets-store-csi-providers: read-only file system`