### PR TITLE
Disabled secrets listing

### DIFF
--- a/images/secrets-store-csi-driver/patches/002-secrets-store-csi-driver.patch
+++ b/images/secrets-store-csi-driver/patches/002-secrets-store-csi-driver.patch
@@ -1,5 +1,5 @@
 diff --git a/cmd/secrets-store-csi-driver/main.go b/cmd/secrets-store-csi-driver/main.go
-index 35406764..1b058c6a 100644
+index ef3dcc5e..eae4bb28 100644
 --- a/cmd/secrets-store-csi-driver/main.go
 +++ b/cmd/secrets-store-csi-driver/main.go
 @@ -52,7 +52,7 @@ import (
@@ -27,6 +27,17 @@ index 35406764..1b058c6a 100644
  			},
  		}),
  	})
+@@ -199,10 +190,6 @@ func mainErr() error {
+ 		}
+ 	}()
+ 
+-	go func() {
+-		reconciler.RunPatcher(ctx)
+-	}()
+-
+ 	// token request client
+ 	kubeClient := kubernetes.NewForConfigOrDie(cfg)
+ 	tokenClient := k8s.NewTokenClient(kubeClient, *driverName, 10*time.Minute)
 diff --git a/controllers/secretproviderclasspodstatus_controller.go b/controllers/secretproviderclasspodstatus_controller.go
 index 8fbee8c1..8803238e 100644
 --- a/controllers/secretproviderclasspodstatus_controller.go
@@ -132,10 +143,22 @@ index 8fbee8c1..8803238e 100644
  	// requeue the spc pod status again after 5mins to check if secret and ownerRef exists
  	// and haven't been modified. If secret doesn't exist, then this requeue will ensure it's
 diff --git a/pkg/rotation/reconciler.go b/pkg/rotation/reconciler.go
-index e82d12f7..4ab91bbf 100644
+index e82d12f7..51cac3e7 100644
 --- a/pkg/rotation/reconciler.go
 +++ b/pkg/rotation/reconciler.go
-@@ -462,58 +462,6 @@ func (r *Reconciler) reconcile(ctx context.Context, spcps *secretsstorev1.Secret
+@@ -145,11 +145,6 @@ func (r *Reconciler) runErr(stopCh <-chan struct{}) error {
+ 	ticker := time.NewTicker(r.rotationPollInterval)
+ 	defer ticker.Stop()
+ 
+-	if err := r.secretStore.Run(stopCh); err != nil {
+-		klog.ErrorS(err, "failed to run informers for rotation reconciler")
+-		return err
+-	}
+-
+ 	// TODO (aramase) consider adding more workers to process reconcile concurrently
+ 	for i := 0; i < 1; i++ {
+ 		go wait.Until(r.runWorker, time.Second, stopCh)
+@@ -462,58 +457,6 @@ func (r *Reconciler) reconcile(ctx context.Context, spcps *secretsstorev1.Secret
  		klog.InfoS("spc doesn't contain secret objects", "spc", klog.KObj(spc), "pod", klog.KObj(pod), "controller", "rotation")
  		return nil
  	}

--- a/templates/secrets-store-csi-driver/rbac-for-us.yaml
+++ b/templates/secrets-store-csi-driver/rbac-for-us.yaml
@@ -111,33 +111,6 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: d8:secrets-store-integration:secrets-store-csi-driver:rotation
-  {{- include "helm_lib_module_labels" (list . (dict "app" "csi-secrets-store" )) | nindent 2 }}
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: d8:secrets-store-integration:secrets-store-csi-driver:rotation
-subjects:
-- kind: ServiceAccount
-  name: secrets-store-csi-driver
-  namespace: d8-{{ $.Chart.Name }}
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: d8:secrets-store-integration:secrets-store-csi-driver:rotation
-  {{- include "helm_lib_module_labels" (list . (dict "app" "csi-secrets-store" )) | nindent 2 }}
-rules:
-- apiGroups:
-  - ""
-  resources:
-  - secrets
-  verbs:
-  - list
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
   name: d8:secrets-store-integration:secrets-store-csi-driver:rbac-proxy
   {{- include "helm_lib_module_labels" (list . (dict "app" "csi-secrets-store")) | nindent 2 }}
 roleRef:


### PR DESCRIPTION
## Description
Disabled secrets listing 

## Why do we need it, and what problem does it solve?
Removed secrets listing because secrets integration is an unused feature

## What is the expected result?
CSI driver should work without list or update kubernetes secrets

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
